### PR TITLE
Update Owl Hash plugin to allow for looping Carousels

### DIFF
--- a/src/js/owl.hash.js
+++ b/src/js/owl.hash.js
@@ -86,6 +86,11 @@
 			if (position === undefined || position === this._core.current()) {
 				return;
 			}
+			
+			//If its a looping slider than we need to factor the cloned items in.
+        		if (this._core._clones.length > 0) {
+                		position = position - (this._core._clones.length / 2);
+            		}
 
 			this._core.to(this._core.relative(position), false, true);
 		}, this));


### PR DESCRIPTION
Resolving issue:
Incorrect slide loaded with URLhash if loop is true #822

Currently the Hash plugin does not factor in the clones when trying to figure out what position to go to, by grabbing the number of clones halving it and then reducing the position by that value the slides should go to the correct place
